### PR TITLE
Add Hessian

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ In the Julia REPL, first load the package SimpleAutoDiff.jl
 julia> using SimpleAutoDiff
 ```
 
-SimpleAutoDiff.jl can compute first-order derivatives of scalar or vector-valued functions of one or several variables.
+SimpleAutoDiff.jl can compute first-order derivatives of scalar or vector-valued functions of one or several variables and Hessian
+matrices for scalar functions with vector input.
 
 ### Derivative of a function $f: \mathbb{R}\to\mathbb{R}$
 
@@ -114,6 +115,32 @@ julia> J([pi, -1])
 ```
 
 Again, there is an in-place version `jacobian!`, which takes a preallocated matrix of correct shape.
+
+### Hessian matrix of a function $f: \mathbb{R}^n\to\mathbb{R}$
+
+You can compute Hessians (i.e. the Jacobian of the gradient) by
+
+```julia
+julia> using LinearAlgebra
+
+julia> f(x) = norm(x)^2
+f (generic function with 1 method)
+
+julia> hessian(f, [1.0, 2.0])
+2×2 Matrix{Float64}:
+ 2.0  0.0
+ 0.0  2.0
+
+julia> H = hessian(f)
+#7 (generic function with 1 method)
+
+julia> H([3.0, 3.0])
+2×2 Matrix{Float64}:
+ 2.0  0.0
+ 0.0  2.0
+```
+
+There also exists the in-place function `hessian!`.
 
 ## Authors
 

--- a/src/SimpleAutoDiff.jl
+++ b/src/SimpleAutoDiff.jl
@@ -7,6 +7,7 @@ import NaNMath
 
 include("dual_numbers.jl")
 include("derivative.jl")
-export DualNumber, value, derivative, gradient, gradient!, jacobian, jacobian!
+export DualNumber,
+    value, derivative, gradient, gradient!, jacobian, jacobian!, hessian, hessian!
 
 end

--- a/src/derivative.jl
+++ b/src/derivative.jl
@@ -91,3 +91,29 @@ end
 Compute the Jacobian matrix of a function `f` and return it as a function.
 """
 jacobian(f) = x0 -> jacobian(f, x0)
+
+"""
+    hessian!(hess, f, x0)
+
+Computes the Hessian matrix of a function `f` mapping a vector to a scalar evaluated at a value `x0`
+in-place and overwrites `hess` by the Hessian.
+
+See also [`hessian`](@ref) for an out-of-place version of the function.
+"""
+hessian!(hess, f, x0) = jacobian!(hess, gradient(f), x0)
+
+"""
+    hessian(f, x0)
+
+Compute the Hessian matrix of a function `f` mapping a vector to a scalar evaluated at a value `x0`.
+
+See also [`hessian!`](@ref) for an in-place version of the function.
+"""
+hessian(f, x0) = jacobian(gradient(f), x0)
+
+"""
+    hessian(f)
+
+Compute the Hessian matrix of a function `f` and return it as a function.
+"""
+hessian(f) = x0 -> hessian(f, x0)

--- a/src/dual_numbers.jl
+++ b/src/dual_numbers.jl
@@ -5,24 +5,34 @@ A struct representing a dual number ``a + εb``, where ``a`` and ``b`` are real 
 representing the `value` and the derivative `deriv` of a function in the context of automatic
 differentiation. Here, ``ε`` is a symbol satisfying ``ε^2 = 0``.
 """
-struct DualNumber{T<:Real} <: Number
+struct DualNumber{T<:Real} <: Real
     value::T
     deriv::T
 end
 
-DualNumber(value::Real, deriv::Real) = DualNumber(promote(value, deriv)...)
+function DualNumber(value::T1, deriv::T2) where {T1,T2}
+    T = promote_type(T1, T2)
+    return DualNumber(convert(T, value), convert(T, deriv))
+end
 
 value(d::DualNumber) = d.value
 derivative(d::DualNumber) = d.deriv
 
-Base.real(::DualNumber{T}) where {T} = T
+Base.eltype(::DualNumber{T}) where {T} = T
+Base.eltype(::Type{DualNumber{T}}) where {T} = T
 Base.float(::Type{DualNumber{T}}) where {T} = DualNumber{T}
 Base.float(d::DualNumber) = convert(float(typeof(d)), d)
 
-Base.convert(::Type{DualNumber{T}}, x::Real) where {T<:Real} = DualNumber(x, zero(T))
+Base.convert(::Type{DualNumber{T}}, x::Number) where {T} = DualNumber(x, zero(T))
+Base.convert(::Type{D}, d::D) where {D<:DualNumber} = d
 Base.promote_rule(::Type{DualNumber{T}}, ::Type{<:Real}) where {T<:Real} = DualNumber{T}
+function Base.promote_rule(::Type{DualNumber{T1}}, ::Type{DualNumber{T2}}) where {T1,T2}
+    return DualNumber{promote_type(T1, T2)}
+end
 
-# rules
+# diff rules
+# Define binary diff rules by hand. We are missing some from DiffRules.jl (e.g. atan, hypot, ...),
+# but since they are not essential we skip them for simplicity.
 Base.:+(x::DualNumber, y::DualNumber) = DualNumber(x.value + y.value, x.deriv + y.deriv)
 Base.:-(x::DualNumber, y::DualNumber) = DualNumber(x.value - y.value, x.deriv - y.deriv)
 function Base.:*(x::DualNumber, y::DualNumber)
@@ -59,9 +69,15 @@ for pred in UNARY_PREDICATES
 end
 
 const BINARY_PREDICATES = Symbol[:isequal, :isless, :<, :>, :(==), :(!=), :(<=), :(>=)]
+# The ambiguous types are needed to avoid method ambiguities. We need to specialize the second non-DualNumber argument.
+# From https://github.com/JuliaDiff/ForwardDiff.jl/blob/v0.10.38/src/dual.jl#L146 and
+# https://github.com/JuliaDiff/ForwardDiff.jl/blob/v0.10.38/src/prelude.jl#L9
+const AMBIGUOUS_TYPES = (AbstractFloat, Irrational, Integer, Rational, Real, RoundingMode)
 
 for pred in BINARY_PREDICATES
     @eval Base.$(pred)(x::DualNumber, y::DualNumber) = $(pred)(value(x), value(y))
-    @eval Base.$(pred)(x::DualNumber, y) = $(pred)(value(x), y)
-    @eval Base.$(pred)(x, y::DualNumber) = $(pred)(x, value(y))
+    for R in AMBIGUOUS_TYPES
+        @eval Base.$(pred)(x::DualNumber, y::$R) = $(pred)(value(x), y)
+        @eval Base.$(pred)(x::$R, y::DualNumber) = $(pred)(x, value(y))
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,11 +14,11 @@ using Test
 
     @testset "Dual numbers" begin
         x = DualNumber(1, 2)
-        @test real(x) == Int64
+        @test eltype(x) == Int64
         @test value(x) == 1
         @test derivative(x) == 2
         y = DualNumber(3, 4.0)
-        @test real(y) == Float64
+        @test eltype(y) == Float64
         @test float(y) == y
         @test value(y) == 3.0
         @test derivative(y) == 4.0
@@ -63,7 +63,9 @@ using Test
 
     @testset "gradient" begin
         f1(x) = sin(x[1]) * cos(x[2])
-        @test isapprox(gradient(f1, [pi, -pi]), [1.0, 0.0], atol = 1e-15)
+        a = [pi, -pi]
+        G = [1.0, 0.0]
+        @test isapprox(gradient(f1, a), G, atol = 1e-15)
         @test gradient(x -> norm(x)^2, [1.0, 2.0]) == [2.0, 4.0]
         f2(x) = tanh(x[1]) * tan(x[1])
         grad = zeros(2)
@@ -72,7 +74,7 @@ using Test
         @test grad == gradient(f2, x0)
 
         h = gradient(f1)
-        @test isapprox(h([-pi, pi]), [1.0, 0.0], atol = 1e-15)
+        @test isapprox(h(a), G, atol = 1e-15)
     end
 
     @testset "jacobian" begin
@@ -92,5 +94,27 @@ using Test
 
         h = jacobian(f1)
         @test isapprox(h(a), J, atol = 1e-15)
+    end
+
+    @testset "hessian" begin
+        f1(x) = sin(x[1]^2) * cos(x[2]^2)
+        a = [pi, -pi]
+        H = [
+            -13.704786185347317 15.334467910643793
+            15.334467910643793 -15.704786185347313
+        ]
+        @test isapprox(hessian(f1, a), H, atol = 1e-15)
+        @test hessian(x -> norm(x)^2, [1.0, 2.0]) == [
+            2.0 0.0
+            0.0 2.0
+        ]
+        f2(x) = tanh(x[1]) * tan(x[1])
+        hess = zeros(2, 2)
+        x0 = [2.0, -1.0]
+        @test_nowarn hessian!(hess, f2, x0)
+        @test hess == hessian(f2, x0)
+
+        h = hessian(f1)
+        @test isapprox(h(a), H, atol = 1e-15)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -59,6 +59,7 @@ using Test
 
         h = derivative(f2)
         @test h(2.0) == -0.25
+        @test derivative(derivative(f1), 1.0) == 8.0
     end
 
     @testset "gradient" begin


### PR DESCRIPTION
For second order derivatives, `DualNumber` needs to be able to hold `DualNumber`s as `value` and `deriv`. Therefore, it needs to `<: Real` and we need some more conversion rules.